### PR TITLE
feat: 답안 체점 로직 구현

### DIFF
--- a/src/main/java/com/example/cs25/domain/quiz/entity/QuizCategory.java
+++ b/src/main/java/com/example/cs25/domain/quiz/entity/QuizCategory.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ public class QuizCategory extends BaseEntity {
 
     private String categoryType;
 
+    @Builder
     public QuizCategory(String categoryType) {
         this.categoryType = categoryType;
     }

--- a/src/main/java/com/example/cs25/domain/quiz/exception/QuizExceptionCode.java
+++ b/src/main/java/com/example/cs25/domain/quiz/exception/QuizExceptionCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum QuizExceptionCode {
 
-    NOT_FOUND_ERROR(false, HttpStatus.NOT_FOUND, "해당 이벤트를 찾을 수 없습니다"),
+    NOT_FOUND_ERROR(false, HttpStatus.NOT_FOUND, "해당 퀴즈를 찾을 수 없습니다"),
     QUIZ_CATEGORY_NOT_FOUND_ERROR(false, HttpStatus.NOT_FOUND, "QuizCategory 를 찾을 수 없습니다"),
     QUIZ_CATEGORY_ALREADY_EXISTS_ERROR(false, HttpStatus.CONFLICT, "이미 해당 카테고리가 존재합니다"),
     JSON_PARSING_FAILED_ERROR(false, HttpStatus.BAD_REQUEST, "JSON 파싱 실패"),

--- a/src/main/java/com/example/cs25/domain/subscription/dto/SubscriptionRequest.java
+++ b/src/main/java/com/example/cs25/domain/subscription/dto/SubscriptionRequest.java
@@ -7,6 +7,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,4 +31,13 @@ public class SubscriptionRequest {
     // 수정하면서 기간을 늘릴수도, 안늘릴수도 있음, 기본값은 0
     @NotNull
     private SubscriptionPeriod period;
+
+    @Builder
+    public SubscriptionRequest(SubscriptionPeriod period, boolean isActive, Set<DayOfWeek> days, String email, String category) {
+        this.period = period;
+        this.isActive = isActive;
+        this.days = days;
+        this.email = email;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/example/cs25/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/cs25/domain/subscription/repository/SubscriptionRepository.java
@@ -11,8 +11,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     boolean existsByEmail(String email);
 
-    Optional<Subscription> findByEmail(String email);
-
     @Query("SELECT s FROM Subscription s JOIN FETCH s.category WHERE s.id = :id")
     Optional<Subscription> findByIdWithCategory(Long id);
 

--- a/src/main/java/com/example/cs25/domain/userQuizAnswer/controller/UserQuizAnswerController.java
+++ b/src/main/java/com/example/cs25/domain/userQuizAnswer/controller/UserQuizAnswerController.java
@@ -1,8 +1,23 @@
 package com.example.cs25.domain.userQuizAnswer.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.example.cs25.domain.userQuizAnswer.requestDto.UserQuizAnswerRequestDto;
+import com.example.cs25.domain.userQuizAnswer.service.UserQuizAnswerService;
+import com.example.cs25.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/quizzes")
+@RequiredArgsConstructor
 public class UserQuizAnswerController {
 
+    private final UserQuizAnswerService userQuizAnswerService;
+
+    @PostMapping("/{quizId}")
+    public ApiResponse<String> answerSubmit(@PathVariable Long quizId, @RequestBody UserQuizAnswerRequestDto requestDto){
+
+        userQuizAnswerService.answerSubmit(quizId, requestDto);
+
+        return new ApiResponse<>(200, "답안이 제출 되었습니다.");
+    }
 }

--- a/src/main/java/com/example/cs25/domain/userQuizAnswer/requestDto/UserQuizAnswerRequestDto.java
+++ b/src/main/java/com/example/cs25/domain/userQuizAnswer/requestDto/UserQuizAnswerRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.cs25.domain.userQuizAnswer.requestDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserQuizAnswerRequestDto {
+
+    private final String answer;
+    private final Long subscriptionId;
+
+    @Builder
+    public UserQuizAnswerRequestDto(String answer, Long subscriptionId) {
+        this.answer = answer;
+        this.subscriptionId = subscriptionId;
+    }
+}

--- a/src/main/java/com/example/cs25/domain/userQuizAnswer/service/UserQuizAnswerService.java
+++ b/src/main/java/com/example/cs25/domain/userQuizAnswer/service/UserQuizAnswerService.java
@@ -1,8 +1,53 @@
 package com.example.cs25.domain.userQuizAnswer.service;
 
+import com.example.cs25.domain.quiz.entity.Quiz;
+import com.example.cs25.domain.quiz.exception.QuizException;
+import com.example.cs25.domain.quiz.exception.QuizExceptionCode;
+import com.example.cs25.domain.quiz.repository.QuizRepository;
+import com.example.cs25.domain.subscription.entity.Subscription;
+import com.example.cs25.domain.subscription.exception.SubscriptionException;
+import com.example.cs25.domain.subscription.exception.SubscriptionExceptionCode;
+import com.example.cs25.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25.domain.userQuizAnswer.entity.UserQuizAnswer;
+import com.example.cs25.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
+import com.example.cs25.domain.userQuizAnswer.requestDto.UserQuizAnswerRequestDto;
+import com.example.cs25.domain.users.entity.User;
+import com.example.cs25.domain.users.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserQuizAnswerService {
 
+    private final UserQuizAnswerRepository userQuizAnswerRepository;
+    private final QuizRepository quizRepository;
+    private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
+
+    public void answerSubmit(Long quizId, UserQuizAnswerRequestDto requestDto) {
+
+        // 구독 정보 조회
+        Subscription subscription = subscriptionRepository.findById(requestDto.getSubscriptionId())
+                .orElseThrow(() -> new SubscriptionException(SubscriptionExceptionCode.NOT_FOUND_SUBSCRIPTION_ERROR));
+
+        // 유저 정보 조회
+        User user = userRepository.findBySubscription(subscription);
+
+        // 퀴즈 조회
+        Quiz quiz = quizRepository.findById(quizId).orElseThrow(() -> new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
+
+        // 정답 체크
+        boolean isCorrect = requestDto.getAnswer().equals(quiz.getAnswer().substring(0,1));
+
+        userQuizAnswerRepository.save(
+                UserQuizAnswer.builder()
+                .userAnswer(requestDto.getAnswer())
+                .isCorrect(isCorrect)
+                .user(user)
+                .quiz(quiz)
+                .subscription(subscription)
+                .build()
+        );
+    }
 }

--- a/src/main/java/com/example/cs25/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/example/cs25/domain/users/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.cs25.domain.users.repository;
 
 import com.example.cs25.domain.oauth2.dto.SocialType;
+import com.example.cs25.domain.subscription.entity.Subscription;
 import com.example.cs25.domain.users.entity.User;
 import com.example.cs25.domain.users.exception.UserException;
 import com.example.cs25.domain.users.exception.UserExceptionCode;
@@ -18,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             }
         });
     }
+
+    User findBySubscription(Subscription subscription);
 }

--- a/src/main/java/com/example/cs25/global/config/AiConfig.java
+++ b/src/main/java/com/example/cs25/global/config/AiConfig.java
@@ -5,19 +5,25 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AiConfig {
+
+    @Value("${spring.ai.openai.api-key}")
+    private String openAiKey;
+
     @Bean
-    public ChatClient chatClient(OpenAiChatModel chatModel){
+    public ChatClient chatClient(OpenAiChatModel chatModel) {
         return ChatClient.create(chatModel);
     }
+
     @Bean
     public EmbeddingModel embeddingModel() {
         OpenAiApi openAiApi = OpenAiApi.builder()
-                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .apiKey(openAiKey)
                 .build();
         return new OpenAiEmbeddingModel(openAiApi);
     }

--- a/src/main/java/com/example/cs25/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cs25/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                 .requestMatchers("/subscription/**").permitAll()
                 .requestMatchers("/emails/**").permitAll()
                 .requestMatchers("/accuracyTest/**").permitAll()
+                .requestMatchers("/quizzes/**").permitAll()
                 .requestMatchers("/crawlers/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/users/**").hasAnyRole(PERMITTED_ROLES)
                 .requestMatchers(HttpMethod.POST, "/quizzes/upload/**")

--- a/src/test/java/com/example/cs25/domain/userQuizAnswer/service/UserQuizAnswerServiceTest.java
+++ b/src/test/java/com/example/cs25/domain/userQuizAnswer/service/UserQuizAnswerServiceTest.java
@@ -1,0 +1,146 @@
+package com.example.cs25.domain.userQuizAnswer.service;
+
+import com.example.cs25.domain.oauth2.dto.SocialType;
+import com.example.cs25.domain.quiz.entity.Quiz;
+import com.example.cs25.domain.quiz.entity.QuizCategory;
+import com.example.cs25.domain.quiz.entity.QuizFormatType;
+import com.example.cs25.domain.quiz.exception.QuizException;
+import com.example.cs25.domain.quiz.repository.QuizRepository;
+import com.example.cs25.domain.subscription.dto.SubscriptionRequest;
+import com.example.cs25.domain.subscription.entity.DayOfWeek;
+import com.example.cs25.domain.subscription.entity.Subscription;
+import com.example.cs25.domain.subscription.exception.SubscriptionException;
+import com.example.cs25.domain.subscription.exception.SubscriptionExceptionCode;
+import com.example.cs25.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25.domain.subscription.service.SubscriptionService;
+import com.example.cs25.domain.userQuizAnswer.entity.UserQuizAnswer;
+import com.example.cs25.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
+import com.example.cs25.domain.userQuizAnswer.requestDto.UserQuizAnswerRequestDto;
+import com.example.cs25.domain.users.entity.Role;
+import com.example.cs25.domain.users.entity.User;
+import com.example.cs25.domain.users.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserQuizAnswerServiceTest {
+
+    @InjectMocks
+    private UserQuizAnswerService userQuizAnswerService;
+
+    @Mock
+    private UserQuizAnswerRepository userQuizAnswerRepository;
+
+    @Mock
+    private QuizRepository quizRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    private Subscription subscription;
+    private User user;
+    private Quiz quiz;
+    private UserQuizAnswerRequestDto requestDto;
+    private final Long quizId = 1L;
+    private final Long subscriptionId = 100L;
+
+    @BeforeEach
+    void setUp() {
+        QuizCategory category = QuizCategory.builder()
+                .categoryType("BECKEND")
+                .build();
+
+        subscription = Subscription.builder()
+                .category(category)
+                .email("test@naver.com")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusMonths(1))
+                .subscriptionType(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+                .build();
+
+        user = User.builder()
+                .email("user@naver.com")
+                .name("김테스터")
+                .socialType(SocialType.KAKAO)
+                .role(Role.USER)
+                .subscription(subscription)
+                .build();
+
+        quiz = Quiz.builder()
+                .type(QuizFormatType.MULTIPLE_CHOICE)
+                .question("Java is?")
+                .answer("1. Programming Language")
+                .commentary("Java is a language.")
+                .choice("1. Programming // 2. Coffee")
+                .category(category)
+                .build();
+
+        requestDto = UserQuizAnswerRequestDto.builder()
+                .subscriptionId(subscriptionId)
+                .answer("1")
+                .build();
+    }
+
+    @Test
+    void answerSubmit_정상_저장된다() {
+        // given
+        when(subscriptionRepository.findById(subscriptionId)).thenReturn(Optional.of(subscription));
+        when(userRepository.findBySubscription(subscription)).thenReturn(user);
+        when(quizRepository.findById(quizId)).thenReturn(Optional.of(quiz));
+
+        ArgumentCaptor<UserQuizAnswer> captor = ArgumentCaptor.forClass(UserQuizAnswer.class);
+
+        // when
+        userQuizAnswerService.answerSubmit(quizId, requestDto);
+
+        // then
+        verify(userQuizAnswerRepository).save(captor.capture());
+        UserQuizAnswer saved = captor.getValue();
+
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getQuiz()).isEqualTo(quiz);
+        assertThat(saved.getSubscription()).isEqualTo(subscription);
+        assertThat(saved.getUserAnswer()).isEqualTo("1");
+        assertThat(saved.getIsCorrect()).isTrue();
+    }
+
+    @Test
+    void answerSubmit_구독없음_예외() {
+        // given
+        when(subscriptionRepository.findById(subscriptionId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userQuizAnswerService.answerSubmit(quizId, requestDto))
+                .isInstanceOf(SubscriptionException.class)
+                .hasMessageContaining("구독 정보를 불러올 수 없습니다.");
+    }
+
+    @Test
+    void answerSubmit_퀴즈없음_예외() {
+        // given
+        when(subscriptionRepository.findById(subscriptionId)).thenReturn(Optional.of(subscription));
+        when(userRepository.findBySubscription(subscription)).thenReturn(user);
+        when(quizRepository.findById(quizId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userQuizAnswerService.answerSubmit(quizId, requestDto))
+                .isInstanceOf(QuizException.class)
+                .hasMessageContaining("해당 퀴즈를 찾을 수 없습니다");
+    }
+}


### PR DESCRIPTION
feat: 답안 체점 로직 구현
test: 
- 정상 체점 후 데이터 저장
- 구독 정보 없는 경우 예외 처리
- 퀴즈 정보 없는 경우 예외 처리

---

## 🔎 작업 내용

- 객관식 답안 채점 기능 구현
- 테스트 코드 작성
---
